### PR TITLE
Add Impressum and footer links

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,9 +3,11 @@
         "CNCF",
         "Eurostar",
         "Gare",
+        "Impressum",
         "Kubecon",
         "kubetrain",
         "LYRIA",
+        "Neuchâtel",
         "Nord",
         "Pancras",
         "Romande"

--- a/contacts.md
+++ b/contacts.md
@@ -7,7 +7,7 @@
 
 ## Slack
 
-You can contact the association members in the `#switzerland` channel on the [CNCF Slack](https://slack.cncf.io/).
+You can contact the association members in the `#switzerland` or `#kcd-suisse-romande` channel on the [CNCF Slack](https://slack.cncf.io/).
 
 ## Social Media
 

--- a/impressum.md
+++ b/impressum.md
@@ -1,0 +1,51 @@
+# Impressum
+
+## Provider of the website
+
+Association "Cloud Native Suisse Romande"  
+CH-2000 Neuchâtel  
+Switzerland
+
+## Purpose
+
+This website provides information about the Association "Cloud Native Suisse Romande", 
+a non-profit organization dedicated to connecting end users, contributors, and maintainers 
+of cloud native computing projects within Suisse Romande (French-speaking regions of Switzerland) 
+and neighboring locations.
+
+## Data Protection
+
+The protection of your personal data is very important to us. We process personal data in 
+accordance with Swiss data protection laws, including the Federal Data Protection Act (DSG).
+For detailed information about how we handle your personal data, please see our 
+[Privacy Policy](governance/policies/1_privacy-policy.md).
+
+## Liability
+
+Although we take great care in preparing the content of this website, we assume no liability 
+for the correctness, completeness, or currency of the information provided. The content is 
+provided "as-is" without any warranty.
+
+We reserve the right to change, supplement, or delete content without prior notice.
+
+## External Links
+
+We are not responsible for the content of external websites linked from this site. 
+The operators of linked sites are solely responsible for their content.
+
+## Copyright and License
+
+This website and its content are licensed under the 
+[Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/).
+
+The Association "Cloud Native Suisse Romande" is a community-driven project operated by volunteers 
+and community leaders.
+
+## Contacts
+
+For general inquiries about the association, 
+please use our [contact email](./contacts.md)
+
+## Last Updated
+
+{{ page.meta.date }}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,8 @@ site_description: >-
   within the Suisse Romande region.
 copyright: >-
   Copyright &copy; 2024-2026 - Association "Cloud Native Suisse Romande" and all contributors.
-  The content and the license are licensed under CC BY 4.0
+  The content and the license are licensed under CC BY 4.0.<br/>
+  <a href="https://www.cloud-native-romandy.ch/privacy-policy">Privacy Policy</a> - <a href="https://www.cloud-native-romandy.ch/impressum">Impressum</a> - <a href="https://www.cloud-native-romandy.ch/contacts">Contacts</a>
 repo_url: https://github.com/cloud-native-suisse-romande/website
 repo_name: GitHub Repo
 edit_uri: edit/main/
@@ -38,10 +39,12 @@ nav:
     - Code of Conduct: governance/bylaws/CODE_OF_CONDUCT.md
     - Membership Process: governance/policies/2_membership-process.md
   - Resources:
+    - Contacts: contacts.md
     - Privacy Policy: governance/policies/1_privacy-policy.md
+    - Impressum: impressum.md
     - Contributing to this Site: CONTRIBUTING.md
     - Content License: LICENSE.txt
-    - Contacts: contacts.md
+
 
 plugins:
   - search
@@ -72,6 +75,7 @@ plugins:
       redirect_maps:
         'events/kcd/README.md': https://kcd.cloud-native-romandy.ch/
         'kcd2025/README.md': https://kcd.cloud-native-romandy.ch/
+        'privacy-policy.md': policies/1_privacy-policy/README.md
 
 
 # Markdown


### PR DESCRIPTION
I am following up on my old actions for the association setup. This PR adds an explicit Impressum, and introduces links in the website footer

Closes #49 