### PR TITLE
Fix LinkedIn link on the site

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -176,7 +176,7 @@ extra:
       link: https://github.com/cloud-native-suisse-romande
       name: GitHub
     - icon: fontawesome/brands/linkedin
-      link: https://www.linkedin.com/company/cloud-native-suisse-romande
+      link: https://www.linkedin.com/company/kcd-suisse-romande/
       name: LinkedIn
     - icon: fontawesome/brands/youtube
       link: https://www.youtube.com/@CloudNativeSuisseRomande


### PR DESCRIPTION
@tpredhom renamed the LinkedIn organization at some poin t last year, and now the redirect has expired